### PR TITLE
输入正则中含有空格会导致正则被截取

### DIFF
--- a/src/main/java/cn/ac/ios/Main.java
+++ b/src/main/java/cn/ac/ios/Main.java
@@ -64,7 +64,7 @@ public class Main {
 
         System.out.println("please input regex ");
         Scanner scanner = new Scanner(System.in);
-        String regex = scanner.next();
+        String regex = scanner.nextLine();
         System.out.println("input:" + regex);
 
         getResult(regex);


### PR DESCRIPTION
`scanner.nextLine()`默认会使用`"\\p{javaWhitespace}+"`做为分隔符，当输入正则中含有空格时，会导致正则被截取

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

e.g. "Closes #000" or "None, as it's a documentation fix."

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self-explanatory."
